### PR TITLE
Add mobile lookup

### DIFF
--- a/app/models/dovecote/msisdn.rb
+++ b/app/models/dovecote/msisdn.rb
@@ -226,6 +226,12 @@ module Dovecote
       "+#{phone_code}.#{subscriber_number}"
     end
 
+    def mobile?
+      Messenger.instance.client.lookup(self.to_s).type == "mobile"
+    rescue MessageBird::ErrorException => e
+      raise e.errors.first.description
+    end
+
     def self.phone_number_to_phone_code(phone_number)
       return unless phone_number
       PhoneCodes.detect { |phone_code, country_codes| phone_number.starts_with?("+#{phone_code}") }.try(:first)


### PR DESCRIPTION
I know it lacks test but I am short on time. There are few things that
could be improved as well, for example extracting MessageBird client to
a separate instance, so Messenger and Msisdn could use it (and mock in
tests as well).
I don't know what time do we have to spend on improvements here, so any
advice would be more than appreciated.